### PR TITLE
:sparkles: Member 엔티티 변환 메서드 & 회원가입 로직 구현

### DIFF
--- a/src/main/java/org/goodpeoplegoodtimes/domain/Member.java
+++ b/src/main/java/org/goodpeoplegoodtimes/domain/Member.java
@@ -1,14 +1,15 @@
 package org.goodpeoplegoodtimes.domain;
 
 import lombok.*;
+import org.goodpeoplegoodtimes.dto.SignupDto;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member {
 
     @Id
@@ -27,5 +28,18 @@ public class Member {
 
     @Column(nullable = false)
     private int imgNum;
+
+    /** Dto > Entity 변환 메서드
+     *
+     * @param signupDto
+     */
+    public static Member of(SignupDto signupDto) {
+        return Member.builder()
+                .email(signupDto.getEmail())
+                .password(signupDto.getPassword())
+                .nickname(signupDto.getNickname())
+                .imgNum(signupDto.getImgNum())
+                .build();
+    }
 
 }

--- a/src/main/java/org/goodpeoplegoodtimes/dto/SignupDto.java
+++ b/src/main/java/org/goodpeoplegoodtimes/dto/SignupDto.java
@@ -1,0 +1,18 @@
+package org.goodpeoplegoodtimes.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupDto {
+
+    private String email;
+    private String password;
+    private String nickname;
+    private int imgNum;
+}

--- a/src/main/java/org/goodpeoplegoodtimes/service/MemberService.java
+++ b/src/main/java/org/goodpeoplegoodtimes/service/MemberService.java
@@ -1,0 +1,20 @@
+package org.goodpeoplegoodtimes.service;
+
+import lombok.RequiredArgsConstructor;
+import org.goodpeoplegoodtimes.domain.Member;
+import org.goodpeoplegoodtimes.dto.SignupDto;
+import org.goodpeoplegoodtimes.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Long signup(SignupDto signupDto) {
+        return memberRepository.save(Member.of(signupDto)).getId();
+    }
+}


### PR DESCRIPTION
- SignupDto : 회원가입 할 때 사용자의 데이터를 담는 dto.
- Member : SignupDto -> Member 엔티티로 변환하는 편의성 메서드 구현.
- MemberService : 회원가입 로직 구현.